### PR TITLE
view-secret: Fix base64 decode option

### DIFF
--- a/view-secret/view-secret.bash
+++ b/view-secret/view-secret.bash
@@ -47,4 +47,4 @@ fi
 escaped_key="${key/./\\.}"
 
 kubectl get secret "${secret}" \
-    -o=jsonpath=\{.data."${escaped_key}"\} | base64 ---decode
+    -o=jsonpath=\{.data."${escaped_key}"\} | base64 --decode


### PR DESCRIPTION
Hey,
the `view-secret` command does not work because the `decode` option is passed using a triple dash. I changed it to a double dash to fix it.

Best,
Dominik