### PR TITLE
view-secret > allow multiple dots in key name

### DIFF
--- a/view-secret/view-secret.sh
+++ b/view-secret/view-secret.sh
@@ -43,7 +43,7 @@ if [[ -z "${key}" ]]; then
     fi
 fi
 
-escaped_key="${key/./\\.}"
+escaped_key="${key//./\\.}"
 
 kubectl get secret "${secret}" \
     -o=jsonpath=\{.data."${escaped_key}"\} | base64 --decode


### PR DESCRIPTION
Hi!
Here's a fix for `view-secret` plugin to allow keys with multiple dots in their name.

Example:
```bash
kubectl view-secret mysecret foo.bar.baz
```