### PR TITLE
Fixed "mapfile: command not found" in Mac

### DIFF
--- a/view-secret/view-secret.sh
+++ b/view-secret/view-secret.sh
@@ -24,9 +24,27 @@ test -z "${1}" && echo >&2 "error: secret name required" && exit 1
 secret="${1}"
 key="${2}"
 
+
+function _kube_list_secs() {
+    IFS=';' read -ra items <<< "$(kubectl get secret "${secret}" -o=json | jq -r '.data | keys[]' | sort -t: | tr '\n' ';')"
+    local count=1
+    lines=$(for i in "${items[@]}"; do
+        IFS=":" read -ra TOKS <<< "${i}"
+        printf "  %s) %s\t%s\n" $count "${TOKS[0]}"
+        ((count=count+1))
+    done | column -t)
+    count=$(echo "$lines" | wc -l)
+    echo "$lines" >&2
+    local sel=0
+    while [[ $sel -lt 1 || $sel -gt $count ]]; do
+        read -r -p "Select a key: " sel >&2
+    done
+    echo "${items[(sel-1)]}"
+}
+
+
 if [[ -z "${key}" ]]; then
-    mapfile -t keys < <(kubectl get secret "${secret}" \
-        -o=json | jq -r '.data | keys[]')
+    IFS=":" read -ra keys <<< "$(_kube_list_secs)"
 
     if [[ "${#keys[@]}" -gt 1 ]]; then
         echo >&2 "Multiple sub keys found. Specify another argument, one of:"


### PR DESCRIPTION
There is no mapfile on the mac, which will cause the key in the secret to fail.
```bash
➜  ~ kubectl-view_secret default-token-qnx54
~/.krew/bin/kubectl-view_secret: line 28: mapfile: command not found
➜  ~
```
after fixing
```bash
➜  ~ kubectl-view_secret default-token-qnx54
1)  ca.crt
2)  namespace
3)  token
Select a key: 2
Choosing key: namespace
default
➜  ~
```