### PR TITLE
mtail fix mapfile for mac and add support for name spaces and multi-container

### DIFF
--- a/mtail/mtail.sh
+++ b/mtail/mtail.sh
@@ -26,7 +26,7 @@ selector="$1"
 namespace="$2 $3"
 container="$4"
 
-pods=$(kubectl get pods -l="app=identity-service" -n argonauts -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}')
+pods=$(kubectl get pods -l="${1}" -n argonauts -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}')
 
 for po in $pods; do
     (

--- a/mtail/plugin.yaml
+++ b/mtail/plugin.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 name: "mtail"
-shortDesc: "Tail logs from multiple pods at once"
+shortDesc: "Tail logs from multiple pods at once and from pods with multiple containers"
 longDesc: >
   Streams logs from multiple pods at once, by selector.
   Uses "kubectl logs --tail=10 --follow"
   Example:
-    $ kubectl plugin mtail app=web,tier=frontend
+    $ kubectl plugin mtail app=web,tier=frontend -n my-namespace my-container
 command: ./mtail.sh


### PR DESCRIPTION
mapfile does not work on mac so replaced.
namespaces can be passed on as parameters now and as well as container name in case of the multi-container pod.